### PR TITLE
Added unit test for movie discovery viewModel and repository

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'androidx.navigation.safeargs'
 android {
     compileSdk 32
 
-    buildFeatures{
+    buildFeatures {
         viewBinding true
     }
 
@@ -68,11 +68,19 @@ dependencies {
             deps.dagger.androidCompiler,
     )
 
+    testImplementation(
+            deps.test.mockK,
+            deps.test.coroutines
+    )
+
+    androidTestImplementation(
+            deps.test.core,
+            deps.test.junit,
+    )
+
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/src/main/java/com/dehcast/filmfinder/ui/movies/discovery/MovieDiscoveryViewModel.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/ui/movies/discovery/MovieDiscoveryViewModel.kt
@@ -1,5 +1,6 @@
 package com.dehcast.filmfinder.ui.movies.discovery
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.dehcast.filmfinder.model.MoviePageResponse
@@ -19,39 +20,46 @@ class MovieDiscoveryViewModel @Inject constructor(
     }
 
     val state: StateFlow<MovieDiscoveryState> by lazy { _state }
-    private var currentPage = 1
-    private var canQueryMore = true
+
+    @VisibleForTesting
+    var currentPage = 1
+
+    @VisibleForTesting
+    var canQueryMore = true
 
     fun fetchMoviePage() {
-        if (state.value == MovieDiscoveryState.Loading || !canQueryMore) return
+        if ((state.value is MovieDiscoveryState.Loading) || !canQueryMore) return
         _state.value = MovieDiscoveryState.Loading
 
         viewModelScope.launch {
             when (val response = movieDiscoveryRepo.fetchMoviePage(currentPage)) {
-                is NetworkResponse.Failure -> handlePageError(response)
+                is NetworkResponse.Failure -> handlePageError()
                 is NetworkResponse.Success -> handlePageFetched(response)
             }
         }
 
     }
 
-    private fun handlePageError(response: NetworkResponse.Failure) {
+    @VisibleForTesting
+    fun handlePageError() {
         _state.value = MovieDiscoveryState.Failure
     }
 
-    private fun handlePageFetched(response: NetworkResponse.Success<MoviePageResponse>) {
-        updateControllingParameters(response.data.totalPages)
+    @VisibleForTesting
+    fun handlePageFetched(response: NetworkResponse.Success<MoviePageResponse>) {
+        checkIfCanStillQueryMore(response.data.totalPages)
         val results = response.data.results
         _state.value =
             if (results.isNullOrEmpty()) MovieDiscoveryState.Failure
             else MovieDiscoveryState.Success(results)
     }
 
-    private fun updateControllingParameters(availablePages: Int?) {
+    @VisibleForTesting
+    fun checkIfCanStillQueryMore(availablePages: Int?) {
+        currentPage++
         availablePages?.let { maxPages ->
             canQueryMore = canQueryMore && currentPage < maxPages
         }
-        currentPage++
     }
 
 }

--- a/app/src/test/java/com/dehcast/filmfinder/repositories/MovieDiscoveryRepositoryTest.kt
+++ b/app/src/test/java/com/dehcast/filmfinder/repositories/MovieDiscoveryRepositoryTest.kt
@@ -1,0 +1,55 @@
+package com.dehcast.filmfinder.repositories
+
+import com.dehcast.filmfinder.apis.MovieDiscoveryApi
+import com.dehcast.filmfinder.model.MoviePageResponse
+import com.dehcast.filmfinder.model.NetworkResponse
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+class MovieDiscoveryRepositoryTest {
+
+    private lateinit var repository: MovieDiscoveryRepository
+
+    @MockK
+    private lateinit var movieDiscoveryApi: MovieDiscoveryApi
+
+    @MockK
+    private lateinit var fakePageResponse: MoviePageResponse
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        repository = MovieDiscoveryRepository(movieDiscoveryApi)
+    }
+
+    @Test
+    fun `on Api exception, fetchMoviePage returns Failure`() = runBlocking {
+        //Given
+        val page = 0
+        coEvery { movieDiscoveryApi.fetchMoviePage(page) }.throws(IllegalStateException())
+
+        //When
+        val response = repository.fetchMoviePage(page)
+
+        //Then
+        assert(response is NetworkResponse.Failure)
+    }
+
+    @Test
+    fun `on Api success, fetchMoviePage returns Success with data`() = runBlocking {
+        //Given
+        val page = 0
+        coEvery { movieDiscoveryApi.fetchMoviePage(page) }.returns(fakePageResponse)
+
+        //When
+        val response = repository.fetchMoviePage(page)
+
+        //Then
+        assert(response is NetworkResponse.Success)
+        assert((response as NetworkResponse.Success).data == fakePageResponse)
+    }
+}

--- a/app/src/test/java/com/dehcast/filmfinder/ui/movies/discovery/MovieDiscoveryViewModelTest.kt
+++ b/app/src/test/java/com/dehcast/filmfinder/ui/movies/discovery/MovieDiscoveryViewModelTest.kt
@@ -1,0 +1,178 @@
+package com.dehcast.filmfinder.ui.movies.discovery
+
+import com.dehcast.filmfinder.model.MoviePageResponse
+import com.dehcast.filmfinder.model.MoviePreview
+import com.dehcast.filmfinder.model.NetworkResponse
+import com.dehcast.filmfinder.repositories.MovieDiscoveryRepository
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class MovieDiscoveryViewModelTest {
+
+    private val repo = mockk<MovieDiscoveryRepository>(relaxed = true)
+    private val viewmodel = spyk(MovieDiscoveryViewModel(repo))
+
+    @MockK
+    private lateinit var FAKE_PAGE_RESPONSE: MoviePageResponse
+
+    @MockK
+    private lateinit var FAILURE: NetworkResponse.Failure
+
+    @MockK
+    private lateinit var SUCCESS: NetworkResponse.Success<MoviePageResponse>
+
+    @MockK
+    private lateinit var FAKE_MOVIES: List<MoviePreview>
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `on state loading, fetchMoviePage doesn't fetch data`() {
+        givenCanQueryMoreTrue()
+        givenStateLoading()
+
+        whenFetchMoviePage()
+
+        //Then
+        coVerify { repo.fetchMoviePage(any()) wasNot called }
+    }
+
+    @Test
+    fun `on flag canQueryMore false, fetchMoviePage doesn't fetch data`() {
+        givenFetchPageFails()
+        givenCanQueryMoreFalse()
+        givenStateNotLoading()
+
+        whenFetchMoviePage()
+
+        //Then
+        coVerify { repo.fetchMoviePage(any()) wasNot called }
+    }
+
+    @Test
+    fun `if state not loading and can query more, data is asked for`() {
+        givenStateNotLoading()
+        givenCanQueryMoreTrue()
+
+        whenFetchMoviePage()
+
+        //Then
+        coVerify(atLeast = 1) { repo.fetchMoviePage(any()) }
+    }
+
+    @Test
+    fun `if repo returns failure on fetchMoviePage, failure state is published`() {
+        givenCanQueryMoreTrue()
+        givenFetchPageFails()
+
+        whenFetchMoviePage()
+
+        //Then
+        assert(viewmodel.state.value is MovieDiscoveryState.Failure)
+    }
+
+    @Test
+    fun `if repo returns success on fetchMoviePage, success state is published`() {
+        givenCanQueryMoreTrue()
+        givenFetchPageSucceeds()
+
+        whenFetchMoviePage()
+
+        //Then
+        val state = viewmodel.state.value
+        assert(state is MovieDiscoveryState.Success)
+        assert((state as MovieDiscoveryState.Success).movies == FAKE_MOVIES)
+    }
+
+    @Test
+    fun `if Movie page has no movies, failure state is published`() {
+        givenSuccessHasNOMovies()
+
+        //When
+        viewmodel.handlePageFetched(SUCCESS)
+
+        //Then
+        assert(viewmodel.state.value is MovieDiscoveryState.Failure)
+    }
+
+    @Test
+    fun `if Movie page has NULL movies, failure state is published`() {
+        givenSuccessHasNULLMovies()
+
+        //When
+        viewmodel.handlePageFetched(SUCCESS)
+
+        //Then
+        assert(viewmodel.state.value is MovieDiscoveryState.Failure)
+    }
+
+    private fun whenFetchMoviePage() {
+        viewmodel.fetchMoviePage()
+    }
+
+    private fun givenFetchPageFails() {
+        coEvery { repo.fetchMoviePage(any()) }.returns(FAILURE)
+    }
+
+    private fun givenFetchPageSucceeds() {
+        coEvery { repo.fetchMoviePage(any()) }.returns(SUCCESS)
+        givenSuccessHasData()
+    }
+
+    private fun givenSuccessHasData() {
+        givenPageWithLotsOfPages()
+        every { FAKE_PAGE_RESPONSE.results }.returns(FAKE_MOVIES)
+        every { FAKE_MOVIES.isEmpty() }.returns(false)
+    }
+
+    private fun givenSuccessHasNULLMovies() {
+        givenPageWithLotsOfPages()
+        every { FAKE_PAGE_RESPONSE.results }.returns(null)
+    }
+
+    private fun givenSuccessHasNOMovies() {
+        givenPageWithLotsOfPages()
+        every { FAKE_PAGE_RESPONSE.results }.returns(emptyList())
+        every { FAKE_MOVIES.isEmpty() }.returns(true)
+    }
+
+    private fun givenPageWithLotsOfPages() {
+        every { SUCCESS.data }.returns(FAKE_PAGE_RESPONSE)
+        every { FAKE_PAGE_RESPONSE.totalPages }.returns(Int.MAX_VALUE)
+    }
+
+    private fun givenCanQueryMoreTrue() {
+        every { viewmodel.canQueryMore }.returns(true)
+    }
+
+    private fun givenCanQueryMoreFalse() {
+        every { viewmodel.canQueryMore }.returns(false)
+    }
+
+    private fun givenStateLoading() {
+        every { viewmodel.state.value }.returns(MovieDiscoveryState.Loading)
+    }
+
+    private fun givenStateNotLoading() {
+        every { viewmodel.state.value }.returns(MovieDiscoveryState.None)
+    }
+
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,13 @@ def deps = [
                 'compiler':             "com.google.dagger:dagger-compiler:$versions.dagger",
                 'androidCompiler':      "com.google.dagger:dagger-android-processor:$versions.dagger"
         ],
-        'loggingInterceptor': "com.squareup.okhttp3:logging-interceptor:4.9.1"
+        'loggingInterceptor': "com.squareup.okhttp3:logging-interceptor:4.9.1",
+        'test': [
+                'core':                 "androidx.test.espresso:espresso-core:3.4.0",
+                'junit':                "androidx.test.ext:junit:1.1.3",
+                'coroutines':           "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0",
+                'mockK':                "io.mockk:mockk:1.11.0",
+        ]
 ]
 
 ext.deps = deps


### PR DESCRIPTION
Added Unit tests for `movie discovery` ViewModel and repository
Made private variables and methods _visible for testing_

Extra:
Added test dependencies
Removed Unused parameter in ViewModel`s handleError method.

For a later story
add strategy to handle `canQueryMore` logic