### PR TITLE
Added api so repo can modify base Url from images

### DIFF
--- a/app/src/main/java/com/dehcast/filmfinder/apis/MovieThumbnailConfigurationApi.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/apis/MovieThumbnailConfigurationApi.kt
@@ -1,0 +1,10 @@
+package com.dehcast.filmfinder.apis
+
+import com.dehcast.filmfinder.model.MovieThumbnailConfigurationResponse
+import retrofit2.http.GET
+
+interface MovieThumbnailConfigurationApi {
+
+    @GET("configuration")
+    suspend fun fetchThumbnailConfiguration(): MovieThumbnailConfigurationResponse
+}

--- a/app/src/main/java/com/dehcast/filmfinder/di/modules/NetworkModule.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/di/modules/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.dehcast.filmfinder.di.modules
 import com.dehcast.filmfinder.BuildConfig
 import com.dehcast.filmfinder.apis.MovieDetailsApi
 import com.dehcast.filmfinder.apis.MovieDiscoveryApi
+import com.dehcast.filmfinder.apis.MovieThumbnailConfigurationApi
 import dagger.Module
 import dagger.Provides
 import okhttp3.Interceptor
@@ -82,4 +83,8 @@ class NetworkModule {
     @Provides
     fun provideMovieDiscoveryApi(retrofit: Retrofit): MovieDiscoveryApi =
         retrofit.create(MovieDiscoveryApi::class.java)
+
+    @Provides
+    fun provideMovieThumbnailConfigurationApi(retrofit: Retrofit): MovieThumbnailConfigurationApi =
+        retrofit.create(MovieThumbnailConfigurationApi::class.java)
 }

--- a/app/src/main/java/com/dehcast/filmfinder/di/modules/RepositoryModule.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/di/modules/RepositoryModule.kt
@@ -1,6 +1,7 @@
 package com.dehcast.filmfinder.di.modules
 
 import com.dehcast.filmfinder.apis.MovieDiscoveryApi
+import com.dehcast.filmfinder.apis.MovieThumbnailConfigurationApi
 import com.dehcast.filmfinder.repositories.MovieDiscoveryRepository
 import com.dehcast.filmfinder.repositories.MovieDiscoveryRepositoryContract
 import dagger.Module
@@ -12,6 +13,9 @@ class RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideMovieDiscoveryRepository(movieDiscoveryApi: MovieDiscoveryApi): MovieDiscoveryRepositoryContract =
-        MovieDiscoveryRepository(movieDiscoveryApi)
+    fun provideMovieDiscoveryRepository(
+        movieDiscoveryApi: MovieDiscoveryApi,
+        thumbnailConfigurationApi: MovieThumbnailConfigurationApi,
+    ): MovieDiscoveryRepositoryContract =
+        MovieDiscoveryRepository(movieDiscoveryApi, thumbnailConfigurationApi)
 }

--- a/app/src/main/java/com/dehcast/filmfinder/model/MoviePageResponse.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/model/MoviePageResponse.kt
@@ -3,10 +3,11 @@ package com.dehcast.filmfinder.model
 import com.google.gson.annotations.SerializedName
 
 data class MoviePageResponse(
-    val page: Int?,
-    val results: List<MoviePreview>?,
+    val page: Int? = null,
+    @SerializedName("results")
+    val movies: List<MoviePreview>? = null,
     @SerializedName("total_results")
-    val totalResults: Int?,
+    val totalResults: Int? = null,
     @SerializedName("total_pages")
-    val totalPages: Int?,
+    val totalPages: Int? = null,
 )

--- a/app/src/main/java/com/dehcast/filmfinder/model/MoviePreview.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/model/MoviePreview.kt
@@ -4,26 +4,26 @@ import com.google.gson.annotations.SerializedName
 
 data class MoviePreview(
     @SerializedName("poster_path")
-    val posterPath: String?,
+    val posterPath: String? = null,
     @SerializedName("adult")
-    val isAdultMovie: Boolean?,
-    val overview: String?,
+    val isAdultMovie: Boolean? = null,
+    val overview: String? = null,
     @SerializedName("release_date")
-    val releaseDate: String?,
+    val releaseDate: String? = null,
     @SerializedName("genre_ids")
-    val genreIds: List<Int>?,
-    val id: Int?,
+    val genreIds: List<Int>? = null,
+    val id: Int? = null,
     @SerializedName("original_title")
-    val originalTitle: String?,
+    val originalTitle: String? = null,
     @SerializedName("original_language")
-    val originalLanguage: String?,
-    val title: String?,
+    val originalLanguage: String? = null,
+    val title: String? = null,
     @SerializedName("backdrop_path")
-    val backdropPath: String?,
-    val popularity: Double?,
+    val backdropPath: String? = null,
+    val popularity: Double? = null,
     @SerializedName("vote_count")
-    val voteCount: Int?,
-    val video: Boolean?,
+    val voteCount: Int? = null,
+    val video: Boolean? = null,
     @SerializedName("vote_average")
-    val voteAverage: Double?,
+    val voteAverage: Double? = null,
 )

--- a/app/src/main/java/com/dehcast/filmfinder/model/MovieThumbnailConfigurationResponse.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/model/MovieThumbnailConfigurationResponse.kt
@@ -1,0 +1,8 @@
+package com.dehcast.filmfinder.model
+
+import com.google.gson.annotations.SerializedName
+
+data class MovieThumbnailConfigurationResponse(
+    @SerializedName("images")
+    val thumbnailConfiguration: ThumbnailConfiguration,
+)

--- a/app/src/main/java/com/dehcast/filmfinder/model/ThumbnailConfiguration.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/model/ThumbnailConfiguration.kt
@@ -1,0 +1,16 @@
+package com.dehcast.filmfinder.model
+
+import com.google.gson.annotations.SerializedName
+
+data class ThumbnailConfiguration(
+    @SerializedName("base_url")
+    val baseUrl: String? = null,
+    @SerializedName("secure_base_url")
+    val secureBaseUrl: String? = null,
+    @SerializedName("backdrop_sizes")
+    val backdropSizes: List<String>? = null,
+    @SerializedName("logo_sizes")
+    val logoSizes: List<String>? = null,
+    @SerializedName("poster_sizes")
+    val posterSizes: List<String>? = null,
+)

--- a/app/src/main/java/com/dehcast/filmfinder/repositories/MovieDiscoveryRepository.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/repositories/MovieDiscoveryRepository.kt
@@ -1,8 +1,12 @@
 package com.dehcast.filmfinder.repositories
 
+import androidx.annotation.VisibleForTesting
 import com.dehcast.filmfinder.apis.MovieDiscoveryApi
+import com.dehcast.filmfinder.apis.MovieThumbnailConfigurationApi
 import com.dehcast.filmfinder.model.MoviePageResponse
+import com.dehcast.filmfinder.model.MoviePreview
 import com.dehcast.filmfinder.model.NetworkResponse
+import com.dehcast.filmfinder.model.ThumbnailConfiguration
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -13,15 +17,48 @@ interface MovieDiscoveryRepositoryContract {
 
 class MovieDiscoveryRepository(
     private val movieDiscoveryApi: MovieDiscoveryApi,
+    private val thumbnailConfigApi: MovieThumbnailConfigurationApi,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : MovieDiscoveryRepositoryContract {
+
+    @VisibleForTesting
+    var thumbnailBaseUrl: String? = null
 
     override suspend fun fetchMoviePage(page: Int): NetworkResponse<MoviePageResponse> =
         withContext(dispatcher) {
             try {
-                NetworkResponse.Success(movieDiscoveryApi.fetchMoviePage(page))
+                val response = movieDiscoveryApi.fetchMoviePage(page)
+                if (thumbnailBaseUrl.isNullOrEmpty()) configureThumbnailBaseUrl()
+                NetworkResponse.Success(modifyPosterUrlForEachMovie(response))
             } catch (e: Throwable) {
                 NetworkResponse.Failure(e)
             }
         }
+
+    @VisibleForTesting
+    suspend fun configureThumbnailBaseUrl() {
+        withContext(dispatcher) {
+            try {
+                thumbnailBaseUrl = getThumbnailUrlFrom(
+                    thumbnailConfigApi.fetchThumbnailConfiguration().thumbnailConfiguration
+                )
+            } catch (e: Throwable) {
+            }
+        }
+    }
+
+    @VisibleForTesting
+    fun modifyPosterUrlForEachMovie(moviePage: MoviePageResponse): MoviePageResponse {
+        val modifiedResults: List<MoviePreview>? = moviePage.movies?.map { movie ->
+            movie.copy(posterPath = thumbnailBaseUrl + movie.posterPath)
+        }
+        return moviePage.copy(movies = modifiedResults)
+    }
+
+    @VisibleForTesting
+    fun getThumbnailUrlFrom(config: ThumbnailConfiguration): String {
+        val baseUrl = config.secureBaseUrl ?: config.baseUrl
+        val posterSizes = config.posterSizes ?: emptyList()
+        return baseUrl + posterSizes.firstOrNull { it.isNotBlank() }
+    }
 }

--- a/app/src/main/java/com/dehcast/filmfinder/ui/movies/discovery/MovieDiscoveryViewModel.kt
+++ b/app/src/main/java/com/dehcast/filmfinder/ui/movies/discovery/MovieDiscoveryViewModel.kt
@@ -48,7 +48,7 @@ class MovieDiscoveryViewModel @Inject constructor(
     @VisibleForTesting
     fun handlePageFetched(response: NetworkResponse.Success<MoviePageResponse>) {
         checkIfCanStillQueryMore(response.data.totalPages)
-        val results = response.data.results
+        val results = response.data.movies
         _state.value =
             if (results.isNullOrEmpty()) MovieDiscoveryState.Failure
             else MovieDiscoveryState.Success(results)

--- a/app/src/test/java/com/dehcast/filmfinder/repositories/MovieDiscoveryRepositoryTest.kt
+++ b/app/src/test/java/com/dehcast/filmfinder/repositories/MovieDiscoveryRepositoryTest.kt
@@ -1,10 +1,12 @@
 package com.dehcast.filmfinder.repositories
 
 import com.dehcast.filmfinder.apis.MovieDiscoveryApi
-import com.dehcast.filmfinder.model.MoviePageResponse
-import com.dehcast.filmfinder.model.NetworkResponse
+import com.dehcast.filmfinder.apis.MovieThumbnailConfigurationApi
+import com.dehcast.filmfinder.model.*
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -18,12 +20,22 @@ class MovieDiscoveryRepositoryTest {
     private lateinit var movieDiscoveryApi: MovieDiscoveryApi
 
     @MockK
+    private lateinit var configApi: MovieThumbnailConfigurationApi
+
+    @MockK
     private lateinit var fakePageResponse: MoviePageResponse
+
+    @MockK
+    private lateinit var thumbnailConfig: ThumbnailConfiguration
+
+    private var expectedUrl: String = ""
+    private val notEmptyUrl = "https://fake"
+    private val notEmptySize = "first poster size"
 
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        repository = MovieDiscoveryRepository(movieDiscoveryApi)
+        repository = MovieDiscoveryRepository(movieDiscoveryApi, configApi)
     }
 
     @Test
@@ -40,16 +52,151 @@ class MovieDiscoveryRepositoryTest {
     }
 
     @Test
-    fun `on Api success, fetchMoviePage returns Success with data`() = runBlocking {
+    fun `on Api success, fetchMoviePage returns Success`() = runBlocking {
         //Given
-        val page = 0
-        coEvery { movieDiscoveryApi.fetchMoviePage(page) }.returns(fakePageResponse)
+        givenMovieDiscoveryApiReturnsValidResponse()
+        givenBaseUrlIsSetTo("path")
+        val page = 1
 
         //When
         val response = repository.fetchMoviePage(page)
 
         //Then
         assert(response is NetworkResponse.Success)
-        assert((response as NetworkResponse.Success).data == fakePageResponse)
+    }
+
+    @Test
+    fun `on ApiSuccess, if baseUrl not set, thumbnailConfigApi is called`() = runBlocking {
+        //Given
+        givenBaseUrlIsEmpty()
+        givenConfigApiReturnsValidConfig()
+        givenMovieDiscoveryApiReturnsValidResponse()
+
+        //When
+        repository.fetchMoviePage(1)
+
+        //Then
+        coVerify(atLeast = 1) { configApi.fetchThumbnailConfiguration() }
+    }
+
+    @Test
+    fun `getThumbnailUrlFrom() returns base secureUrl and posterSize from config if available`() {
+        givenExpectedUrlIsComposedOf(notEmptyUrl, notEmptySize)
+        givenConfigHasSecureBaseUrlAs(notEmptyUrl)
+        givenConfigHasPosterSizes(listOf(notEmptySize))
+
+        //When
+        val response = repository.getThumbnailUrlFrom(thumbnailConfig)
+
+        //Then
+        assert(response == expectedUrl)
+    }
+
+    @Test
+    fun `if no secureUrl getThumbnailUrlFrom(), uses baseUrl`() {
+        givenExpectedUrlIsComposedOf(notEmptyUrl, notEmptySize)
+        givenConfigHasSecureBaseUrlAs(null)
+        givenConfigHasBaseUrlAs(notEmptyUrl)
+        givenConfigHasPosterSizes(listOf(notEmptySize))
+
+        //When
+        val response = repository.getThumbnailUrlFrom(thumbnailConfig)
+
+        //Then
+        assert(response == expectedUrl)
+    }
+
+    @Test
+    fun `getThumbnailUrlFrom() uses first not empty posterSize`() {
+        givenExpectedUrlIsComposedOf(notEmptyUrl, notEmptySize)
+        givenConfigHasSecureBaseUrlAs(notEmptyUrl)
+        givenConfigHasPosterSizes(listOf("", "", notEmptySize))
+
+        //When
+        val response = repository.getThumbnailUrlFrom(thumbnailConfig)
+
+        //Then
+        assert(response == expectedUrl)
+    }
+
+    @Test
+    fun `configureThumbnailBaseUrl() is not set if network exception happens`() = runBlocking {
+        //Given
+        givenBaseUrlIsEmpty()
+        coEvery { configApi.fetchThumbnailConfiguration() }.throws(IllegalStateException())
+
+        //When
+        repository.configureThumbnailBaseUrl()
+
+        //Then
+        assert(repository.thumbnailBaseUrl?.isEmpty() == true)
+    }
+
+    @Test
+    fun `configureThumbnailBaseUrl() is set with api parameters on response`() = runBlocking {
+        givenConfigApiReturnsValidConfig()
+        givenBaseUrlIsEmpty()
+
+        //When
+        repository.configureThumbnailBaseUrl()
+
+        //Then
+        assert(repository.thumbnailBaseUrl?.isEmpty() == false)
+    }
+
+    @Test
+    fun `modifyPosterUrlForEachMovie adds baseurl to each movie poster posterPath`() {
+        //Given
+        val baseUrl = "Https://test"
+        givenBaseUrlIsSetTo(baseUrl)
+        val pageResponse = getPageResponseWithOneMovie()
+
+        //When
+        val response = repository.modifyPosterUrlForEachMovie(pageResponse)
+
+        //Then
+        assert(response.movies?.get(0)?.posterPath?.contains(baseUrl) == true)
+    }
+
+    private fun givenMovieDiscoveryApiReturnsValidResponse() {
+        val pageResponse = getPageResponseWithOneMovie()
+        coEvery { movieDiscoveryApi.fetchMoviePage(any()) }.returns(pageResponse)
+    }
+
+    private fun getPageResponseWithOneMovie(): MoviePageResponse = MoviePageResponse(
+        movies = listOf(MoviePreview(posterPath = "path"))
+    )
+
+    private fun givenConfigApiReturnsValidConfig() {
+        coEvery { configApi.fetchThumbnailConfiguration() }.returns(
+            MovieThumbnailConfigurationResponse(thumbnailConfig)
+        )
+        givenConfigHasSecureBaseUrlAs(notEmptyUrl)
+        givenConfigHasPosterSizes(listOf(notEmptySize))
+
+    }
+
+    private fun givenBaseUrlIsEmpty() {
+        repository.thumbnailBaseUrl = ""
+    }
+
+    private fun givenBaseUrlIsSetTo(url: String?) {
+        repository.thumbnailBaseUrl = url
+    }
+
+    private fun givenExpectedUrlIsComposedOf(url: String, size: String) {
+        expectedUrl = url + size
+    }
+
+    private fun givenConfigHasSecureBaseUrlAs(url: String?) {
+        every { thumbnailConfig.secureBaseUrl }.returns(url)
+    }
+
+    private fun givenConfigHasBaseUrlAs(url: String?) {
+        every { thumbnailConfig.baseUrl }.returns(url)
+    }
+
+    private fun givenConfigHasPosterSizes(sizes: List<String>) {
+        every { thumbnailConfig.posterSizes }.returns(sizes)
     }
 }

--- a/app/src/test/java/com/dehcast/filmfinder/ui/movies/discovery/MovieDiscoveryViewModelTest.kt
+++ b/app/src/test/java/com/dehcast/filmfinder/ui/movies/discovery/MovieDiscoveryViewModelTest.kt
@@ -139,18 +139,18 @@ class MovieDiscoveryViewModelTest {
 
     private fun givenSuccessHasData() {
         givenPageWithLotsOfPages()
-        every { FAKE_PAGE_RESPONSE.results }.returns(FAKE_MOVIES)
+        every { FAKE_PAGE_RESPONSE.movies }.returns(FAKE_MOVIES)
         every { FAKE_MOVIES.isEmpty() }.returns(false)
     }
 
     private fun givenSuccessHasNULLMovies() {
         givenPageWithLotsOfPages()
-        every { FAKE_PAGE_RESPONSE.results }.returns(null)
+        every { FAKE_PAGE_RESPONSE.movies }.returns(null)
     }
 
     private fun givenSuccessHasNOMovies() {
         givenPageWithLotsOfPages()
-        every { FAKE_PAGE_RESPONSE.results }.returns(emptyList())
+        every { FAKE_PAGE_RESPONSE.movies }.returns(emptyList())
         every { FAKE_MOVIES.isEmpty() }.returns(true)
     }
 


### PR DESCRIPTION
**What this commit does:**

- Added `thumbnail configuration API` to pull base URL and smallest size available for movie thumbnails
- added `thumbnail configuration API` to `movieDiscoveryRepo`
- Added repository tests to account for the new functionality
- Added default values to some `MovieDiscoveryResponse` parameters