### PR TITLE
Limited movie preview auxiliary data to one line

### DIFF
--- a/app/src/main/res/layout/row_item_movie.xml
+++ b/app/src/main/res/layout/row_item_movie.xml
@@ -40,7 +40,9 @@
         style="@style/Theme.FilmFinder.Text.FilmSpecs.Compressed"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:ellipsize="end"
         android:gravity="end"
+        android:maxLines="1"
         app:layout_constraintEnd_toEndOf="@id/thumbnail_container"
         app:layout_constraintTop_toBottomOf="@id/thumbnail_container"
         tools:text="Action" />
@@ -50,7 +52,9 @@
         style="@style/Theme.FilmFinder.Text.FilmSpecs.Compressed"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:ellipsize="end"
         android:gravity="end"
+        android:maxLines="1"
         app:layout_constraintEnd_toEndOf="@id/thumbnail_container"
         app:layout_constraintTop_toBottomOf="@id/genre"
         tools:text="5/7" />
@@ -60,7 +64,9 @@
         style="@style/Theme.FilmFinder.Text.FilmSpecs.Compressed"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:ellipsize="end"
         android:gravity="end"
+        android:maxLines="1"
         app:layout_constraintEnd_toEndOf="@id/thumbnail_container"
         app:layout_constraintTop_toBottomOf="@id/popularity"
         tools:text="1999" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -29,7 +29,6 @@
     </style>
 
     <style name="Theme.FilmFinder.Text.FilmSpecs.Compressed" parent="Theme.FilmFinder.Text.FilmSpecs">
-        <item name="maxLines">1</item>
         <item name="layout_constraintWidth_percent">0.35</item>
     </style>
 </resources>


### PR DESCRIPTION
For the `movieDiscovery` ViewHolders' `genre`, `rate` and `year`:

- Moved max lines attribute from style to text views
- Added ellipse attribute to text views